### PR TITLE
Fix missing header in out of source build install

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,7 @@ set (LIB_SOURCES
 )
 
 set(HEADERS
-    alphabet.h basic.h fst.h interface.h mem.h utf8.h fst-compiler.h
+    alphabet.h basic.h fst.h interface.h mem.h utf8.h ${CMAKE_CURRENT_BINARY_DIR}/fst-compiler.h
 )
 
 # Add library


### PR DESCRIPTION
When doing install in debian packaging this generated file is
unavailable and throws error
install cannot find fst-compiler.h no such file or directory