### PR TITLE
Add sfst subdir to header install path

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,7 +107,7 @@ install(TARGETS libsfst
     RUNTIME DESTINATION lib)
 
 # Install the headers
-install(FILES ${HEADERS} DESTINATION include)
+install(FILES ${HEADERS} DESTINATION include/${PROJECT_NAME})
 
 file(GLOB_RECURSE SOURCE_FILES *.cpp)
 


### PR DESCRIPTION
* Fixes #31 

This change could break projects that fetches the sfst headers from a fixed path.
 Adding a pkg-config metadata file could make the headers easily discoverable. 